### PR TITLE
fix: cross-domain XHR issue in Phantom 2.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,7 @@ var PhantomJQuery = module.exports = {
         };
 
         // Open phantom
+        var args = {parameters: {'web-security': 'no'}};
         openPhantom(ph => {
             // Create the page
             ph.createPage(page => {
@@ -63,7 +64,7 @@ var PhantomJQuery = module.exports = {
                     });
                 });
             });
-        });
+        }, args);
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/IonicaBizau/phantom-jquery/issues/6#issuecomment-245038181

Passing additional argument `{parameter: {'web-security': 'no'}}` to the `openPhantom()` method turns off web security for phantom and fixes the issue
